### PR TITLE
Initial release

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,75 @@
+{
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch",
+    "finally",
+    "with"
+  ],
+  "requireSpaceAfterKeywords": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInFunctionDeclaration": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInFunctionDeclaration": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInCallExpression": true,
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "requireBlocksOnNewline": 1,
+  "disallowPaddingNewlinesInBlocks": true,
+  "disallowSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInsideArrayBrackets": "all",
+  "disallowSpacesInsideParentheses": true,
+  "disallowQuotedKeysInObjects": "allButReserved",
+  "disallowSpaceAfterObjectKeys": true,
+  "requireSpaceBeforeObjectValues": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireOperatorBeforeLineBreak": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowSpaceBeforePostfixUnaryOperators": true,
+  "requireSpaceBeforeBinaryOperators": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+  "disallowKeywords": [
+    "with"
+  ],
+  "disallowMultipleLineStrings": true,
+  "disallowMultipleLineBreaks": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowTrailingComma": true,
+  "disallowKeywordsOnNewLine": [
+    "else",
+    "catch",
+    "finally"
+  ],
+  "requireLineFeedAtFileEnd": true,
+  "maximumLineLength": {
+    "value": 120,
+    "allowUrlComments": true
+  },
+  "requireDotNotation": true,
+  "disallowYodaConditions": true,
+  "requireSpaceAfterLineComment": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "validateLineBreaks": "LF",
+  "validateQuoteMarks": {
+    "mark": "'",
+    "escape": true
+  },
+  "validateIndentation": 2,
+  "validateParameterSeparator": ", ",
+  "safeContextKeyword": [
+    "that"
+  ]
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,28 @@
+{
+  "eqeqeq": true,
+  "freeze": true,
+  "immed": true,
+  "latedef": true,
+  "nonbsp": true,
+  "undef": true,
+  "strict": false,
+  "node": true,
+  "sub": false,
+  "globals": {
+    "exports": true,
+    "describe": true,
+    "before": true,
+    "beforeEach": true,
+    "after": true,
+    "afterEach": true,
+    "it": true
+  },
+  "curly": true,
+  "indent": 2,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "unused": "vars",
+  "maxparams": 4,
+  "maxdepth": 5
+}

--- a/README.md
+++ b/README.md
@@ -2,19 +2,44 @@
 
 Low level query completion for Elasticsearch
 
+This was built as part of an internal tool to autocomplete queries for Elasticsearch.
+
 ## Getting Started
 Install the module with: `npm install elasticsearch-completion`
 
 ```js
-var elasticsearchCompletion = require('elasticsearch-completion');
-elasticsearchCompletion(); // 'awesome'
+// Create a completion class
+var ElasticsearchCompletion = require('elasticsearch-completion');
+var esCompletion = new ElasticsearchCompletion([
+    'name',
+    'location'
+]);
+
+// Supply some queries to complete against
+esCompletion.match(''); // ['name:', 'location:', '_exists_:', '_missing_:']
+esCompletion.match('na'); // ['name:']
+esCompletion.match('name:'); // []
+esCompletion.match('_exists_:'); // ['_exists_:name', '_exists_:location']
 ```
 
 ## Documentation
-_(Coming soon)_
+`elasticsearch-completion` exposes `ElasticsearchCompletion` via its `module.exports`.
 
-## Examples
-_(Coming soon)_
+### `new ElasticsearchCompletion(fields)`
+Constructor for a new completion class
+
+- fields `Array` - Names of fields to match against (e.g. `name`, `location`)
+    - For example, `['foo', 'bar']` would supply matches agains the fields `foo` and `bar`
+
+#### `esCompletion.match(query)`
+Find matching completions for an Elasticsearch query
+
+- query `String` - Query being used in Elasticsearch
+
+**Returns:**
+
+- matches `Array` - Collection of matching completions for the query
+    - For example, `na` might complete to `['name:']` and `_ex` might complete to `['_exists_:']`
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint via `npm run lint` and test via `npm test`.

--- a/lib/elasticsearch-completion.js
+++ b/lib/elasticsearch-completion.js
@@ -1,7 +1,140 @@
-// Define our function
-function elasticsearchCompletion() {
-  return 'awesome';
-}
+// Load in our dependencies
+var parse = require('lucene-query-parser').parse;
 
-// Export our function
-module.exports = elasticsearchCompletion;
+/*
+  Constructor for ElasticsearchCompletion
+  @param {Array} fields - Collection of names of fields to complete with
+  @param {String} fields.* - Name of field to complete with (e.g. `name`, `location`)
+*/
+function ElasticsearchCompletion(fields, options) {
+  // Save fields for later
+  this.fields = fields;
+
+  // Pre-emptively create other field info
+  this.allFields = fields.concat(ElasticsearchCompletion._magicFields);
+  // `foo:`, `_exists_:`, `_missing_:`
+  this.allFieldsWithColons = this.allFields.map(function addColon (field) {
+    return field + ':';
+  });
+}
+ElasticsearchCompletion.IMPLICIT = '<implicit>';
+
+// Internal class method for finding the rightmost result from our parser results
+ElasticsearchCompletion._getRightmostResult = function (results) {
+  // Example parse results from `lucene-query-parser`
+  // `foo` -> `{left: {field: <implicit>, term: foo}}`
+  // `foo:bar` -> `{left: {field: foo, term: bar}}`
+  // `foo:bar AND fuu:baz` -> `{left: {field: foo, term: bar}, operator: AND, right: {field: fuu, term: baz}}`
+  // `foo:bar AND fuu:baz AND aaa:bbb` ->
+  //    `{left: {field: foo, term: bar}, operator: AND, right:
+  //        {left: {field: fuu, term: baz}, operator: AND, right: {field: aaa, term: bbb}}}`
+
+  // If there is at least 1 operator
+  if (results.right) {
+    // If there are at least 2 operators, recurse on the rightmost operator's set
+    if (results.right.left) {
+      return ElasticsearchCompletion._getRightmostResult(results.right);
+    // Otherwise, return the right evaluation
+    } else {
+      return results.right;
+    }
+  // Otherwise, return the only result
+  } else {
+    return results.left;
+  }
+};
+
+// Define constants for special fields
+ElasticsearchCompletion._magicFields = [
+  '_exists_',
+  '_missing_'
+];
+
+ElasticsearchCompletion.prototype = {
+  // Method to result matches for a query string
+  match: function (query) {
+    // Define helper functions
+    function addToQuery(str) {
+      return query + str;
+    }
+
+    // If the string is empty or the rightmost character is whitespace, then provide default prompts
+    //   e.g. "Search: `<empty>`" or "Search: `hello:world `"
+    var results, rightmostResult;
+    if (!query || query[query.length - 1] === ' ') {
+      // `foo:bar` -> `foo:bar foo:`, `foo:bar _exists_:`
+      return this.allFieldsWithColons.map(addToQuery);
+    // Otherwise, if the final character is a colon
+    } else if (query[query.length - 1] === ':') {
+      // Attempt to parse the query without the colon
+      // DEV: `lucene-query-parser` has issues with parsing on colons
+      results = parse(query.slice(0, -1));
+
+      // Find the rightmost result
+      rightmostResult = ElasticsearchCompletion._getRightmostResult(results);
+
+      // If the left hand side is an operator on a field name (e.g. `_exists_`, `_missing_`), exit with fields
+      // DEV: `_exists__:` -> `_exists_` = {field: <implicit>, term: _exists_}}
+      //   e.g. `_exists_:` -> `_exists_:foo`
+      if (ElasticsearchCompletion._magicFields.indexOf(rightmostResult.term) !== -1) {
+        return this.fields.map(addToQuery);
+      // Otherwise, exit with nothing
+      } else {
+        return [];
+      }
+    // Otherwise (we have an incomplete field or incomplete term)
+    } else {
+      // Parse the query
+      results = parse(query);
+
+      // Find the rightmost result
+      rightmostResult = ElasticsearchCompletion._getRightmostResult(results);
+
+      // If our field is incomplete (i.e. no colon yet), then auto-suggest based on the field name
+      //   `f` ({field: <implicit>, term: f}) -> `foo`
+      var matchingFields;
+      if (rightmostResult.field === ElasticsearchCompletion.IMPLICIT) {
+        // Find fields that match (e.g. `f` against `[foo, bar]` -> `oo`), so we can concatenate properly
+        matchingFields = this.matcher(rightmostResult.term, this.allFields);
+
+        // Return the matching field pieces as part of the query
+        return matchingFields.map(function addColonAndQuery (match) {
+          return addToQuery(match + ':');
+        });
+      // Otherwise (there is a completed field)
+      } else {
+        // If the field is an operator on a field name (e.g. `_exists_`, `_missing_`),
+        //   match the "term" against field names
+        if (ElasticsearchCompletion._magicFields.indexOf(rightmostResult.field) !== -1) {
+          matchingFields = this.matcher(rightmostResult.term, this.fields);
+          return matchingFields.map(addToQuery);
+        // Otherwise, return nothing
+        } else {
+          return [];
+        }
+      }
+    }
+  },
+  matcher: function (targetStr, possibleMatches) {
+    // For each of our possible matches
+    var matches = [];
+    var i = 0;
+    var len = possibleMatches.length;
+    for (; i < len; i++) {
+      // If the possible match is shorter than the target itself, skip it
+      var possibleMatch = possibleMatches[i];
+      if (possibleMatch.length < targetStr.length) {
+        continue;
+      // Otherwise, if the possible match is the starting string of the target, save the remaining matching piece
+      } else if (possibleMatch.slice(0, targetStr.length) === targetStr) {
+        matches.push(possibleMatch.slice(targetStr.length));
+      }
+    }
+
+    // Return our matching results
+    return matches;
+  }
+};
+
+// Expose our class
+module.exports = ElasticsearchCompletion;

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
   "scripts": {
     "precheck": "twolfson-style precheck lib/ test/",
     "lint": "twolfson-style lint lib/ test/",
-    "pretest": "twolfson-style install",
     "test": "npm run precheck && mocha --reporter dot && npm run lint"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lucene-query-parser": "~1.0.1"
+  },
   "devDependencies": {
-    "jscs": "~1.7.3",
+    "jscs": "~1.13.1",
     "jshint": "~2.5.10",
     "mocha": "~1.11.0",
     "twolfson-style": "~1.6.0"

--- a/test/elasticsearch-completion-test.js
+++ b/test/elasticsearch-completion-test.js
@@ -1,10 +1,191 @@
 // Load in dependencies
 var assert = require('assert');
-var elasticsearchCompletion = require('../');
+var parse = require('lucene-query-parser').parse;
+var ElasticsearchCompletion = require('../');
 
 // Start our tests
-describe('elasticsearch-completion', function () {
-  it('returns awesome', function () {
-    assert.strictEqual(elasticsearchCompletion(), 'awesome');
+describe('An instance of ElasticsearchCompletion', function () {
+  before(function createCompletion () {
+    this.esCompletion = new ElasticsearchCompletion([
+      'name',
+      'location'
+    ]);
+  });
+
+  describe('completing an empty string', function () {
+    it('returns all possible field completions including special ones', function () {
+      var matches = this.esCompletion.match('');
+      assert.deepEqual(matches, [
+        'name:',
+        'location:',
+        '_exists_:',
+        '_missing_:'
+      ]);
+    });
+  });
+
+  describe('completing a query with a partial field', function () {
+    describe('for a special field (e.g. `_exists_`, `_missing_`)', function () {
+      it('returns the query with matching field completions', function () {
+        var matches = this.esCompletion.match('_ex');
+        assert.deepEqual(matches, [
+          '_exists_:'
+        ]);
+      });
+    });
+
+    describe('for a normal field', function () {
+      it('returns the query with matching field completions', function () {
+        var matches = this.esCompletion.match('na');
+        assert.deepEqual(matches, [
+          'name:'
+        ]);
+      });
+    });
+
+    describe('for no matching fields', function () {
+      it('returns no matches', function () {
+        var matches = this.esCompletion.match('notafield');
+        assert.deepEqual(matches, []);
+      });
+    });
+  });
+
+  describe('completing a query with a field and a colon', function () {
+    describe('for a special field (e.g. `_exists_`, `_missing_`)', function () {
+      it('returns the query with matching term completions', function () {
+        var matches = this.esCompletion.match('_missing_:');
+        assert.deepEqual(matches, [
+          '_missing_:name',
+          '_missing_:location'
+        ]);
+      });
+    });
+
+    describe('for a normal field', function () {
+      // TODO: This should become matching hints
+      it('returns no matches', function () {
+        var matches = this.esCompletion.match('name:');
+        assert.deepEqual(matches, []);
+      });
+    });
+
+    describe('for no matching fields', function () {
+      it('returns no matches', function () {
+        var matches = this.esCompletion.match('doesnotexist:');
+        assert.deepEqual(matches, []);
+      });
+    });
+  });
+
+  describe('completing a query with a field, colon, and partial term', function () {
+    describe('for a special field (e.g. `_exists_`, `_missing_`)', function () {
+      it('returns the query with matching fields as term completions', function () {
+        var matches = this.esCompletion.match('_exists_:n');
+        assert.deepEqual(matches, [
+          '_exists_:name'
+        ]);
+      });
+    });
+
+    describe('for a normal field', function () {
+      // TODO: This should become matching hints
+      it('returns no matches', function () {
+        var matches = this.esCompletion.match('name:to');
+        assert.deepEqual(matches, []);
+      });
+    });
+
+    describe('for no matching fields', function () {
+      it('returns no matches', function () {
+        var matches = this.esCompletion.match('unknown:wa');
+        assert.deepEqual(matches, []);
+      });
+    });
+  });
+
+  describe('completing a query with trailing whitespace', function () {
+    it('returns all possible field completions including special ones', function () {
+      var matches = this.esCompletion.match('_exists_:name ');
+      assert.deepEqual(matches, [
+        '_exists_:name name:',
+        '_exists_:name location:',
+        '_exists_:name _exists_:',
+        '_exists_:name _missing_:'
+      ]);
+    });
+  });
+});
+
+// Inner unit tests
+describe('A query with 1 explicit ANDs', function () {
+  describe('when parsed via ElasticsearchCompletion.getRightmostResult', function () {
+    it('returns the rightmost result', function () {
+      var results = parse('foo:bar AND fuu:baz');
+      assert.deepEqual(ElasticsearchCompletion._getRightmostResult(results), {
+        field: 'fuu',
+        term: 'baz'
+      });
+    });
+  });
+});
+
+describe('A query with 2 explicit ANDs', function () {
+  describe('when parsed via ElasticsearchCompletion.getRightmostResult', function () {
+    it('returns the rightmost result', function () {
+      var results = parse('foo:bar AND fuu:baz AND aaa:bbb');
+      assert.deepEqual(ElasticsearchCompletion._getRightmostResult(results), {
+        field: 'aaa',
+        term: 'bbb'
+      });
+    });
+  });
+});
+
+describe('A query with 1 implicit ANDs', function () {
+  describe('when parsed via ElasticsearchCompletion.getRightmostResult', function () {
+    it('returns the rightmost result', function () {
+      var results = parse('foo:bar fuu:baz');
+      assert.deepEqual(ElasticsearchCompletion._getRightmostResult(results), {
+        field: 'fuu',
+        term: 'baz'
+      });
+    });
+  });
+});
+
+describe('A query with 2 implicit ANDs', function () {
+  describe('when parsed via ElasticsearchCompletion.getRightmostResult', function () {
+    it('returns the rightmost result', function () {
+      var results = parse('foo:bar fuu:baz aaa:bbb');
+      assert.deepEqual(ElasticsearchCompletion._getRightmostResult(results), {
+        field: 'aaa',
+        term: 'bbb'
+      });
+    });
+  });
+});
+
+describe('A query with 2 fields with no terms', function () {
+  describe('when parsed via ElasticsearchCompletion.getRightmostResult', function () {
+    it('returns the rightmost result', function () {
+      var results = parse('foo AND fuu');
+      assert.deepEqual(ElasticsearchCompletion._getRightmostResult(results), {
+        field: ElasticsearchCompletion.IMPLICIT,
+        term: 'fuu'
+      });
+    });
+  });
+});
+
+describe('A query with 3 fields with no terms', function () {
+  describe('when parsed via ElasticsearchCompletion.getRightmostResult', function () {
+    it('returns the rightmost result', function () {
+      var results = parse('foo AND fuu AND aaa');
+      assert.deepEqual(ElasticsearchCompletion._getRightmostResult(results), {
+        field: ElasticsearchCompletion.IMPLICIT,
+        term: 'aaa'
+      });
+    });
   });
 });


### PR DESCRIPTION
We have written, abstracted, and tested `ElasticsearchCompletion`. Now it's time to release it into the wild. In this PR:
- Added `ElasticsearchCompletion` library
- Added tests
- Added documentation

/cc @brettlangdon 
