### PR TITLE
Repaired handling of case with colon on non-rightmost word

### DIFF
--- a/lib/elasticsearch-completion.js
+++ b/lib/elasticsearch-completion.js
@@ -58,17 +58,26 @@ ElasticsearchCompletion.prototype = {
       return query + str;
     }
 
+    // If there is no query (or it's an empty string), return all possible matches
+    if (!query) {
+      return this.allFieldsWithColons.map(addToQuery);
+    }
+
+    // Make our query safe for parsing by removing any colons trailed by whitespace
+    // DEV: These will inevitably cause grammar parsing errors
+    var safeQuery = query.replace(/:(\s)/g, '$1');
+
     // If the string is empty or the rightmost character is whitespace, then provide default prompts
     //   e.g. "Search: `<empty>`" or "Search: `hello:world `"
     var results, rightmostResult;
-    if (!query || query[query.length - 1] === ' ') {
+    if (query[query.length - 1] === ' ') {
       // `foo:bar` -> `foo:bar foo:`, `foo:bar _exists_:`
       return this.allFieldsWithColons.map(addToQuery);
     // Otherwise, if the final character is a colon
     } else if (query[query.length - 1] === ':') {
       // Attempt to parse the query without the colon
       // DEV: `lucene-query-parser` has issues with parsing on colons
-      results = parse(query.slice(0, -1));
+      results = parse(safeQuery.slice(0, -1));
 
       // Find the rightmost result
       rightmostResult = ElasticsearchCompletion._getRightmostResult(results);
@@ -85,7 +94,7 @@ ElasticsearchCompletion.prototype = {
     // Otherwise (we have an incomplete field or incomplete term)
     } else {
       // Parse the query
-      results = parse(query);
+      results = parse(safeQuery);
 
       // Find the rightmost result
       rightmostResult = ElasticsearchCompletion._getRightmostResult(results);

--- a/test/elasticsearch-completion-test.js
+++ b/test/elasticsearch-completion-test.js
@@ -189,3 +189,22 @@ describe('A query with 3 fields with no terms', function () {
     });
   });
 });
+
+// Edge cases
+// DEV: This case was causing errors since the grammar wasn't valid
+describe('A query with colon on the non-rightmost field', function () {
+  before(function createCompletion () {
+    this.esCompletion = new ElasticsearchCompletion([
+      'name'
+    ]);
+  });
+
+  describe('when completed', function () {
+    it('has no errors', function () {
+      var matches = this.esCompletion.match('name: _exists_:n');
+      assert.deepEqual(matches, [
+        'name: _exists_:name'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
We had a regression internally where queries like `a: b:c` were causing the parser to error out. In this PR:
- Added regression test for non-rightmost words containing colons on their right side
- Added patch for parsing error-prone queries

/cc @brettlangdon 
