### PR TITLE
Added foundry for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "lucene-query-parser": "~1.0.1"
   },
   "devDependencies": {
+    "foundry": "~4.3.2",
+    "foundry-release-git": "~2.0.2",
+    "foundry-release-npm": "~2.0.2",
     "jscs": "~1.13.1",
     "jshint": "~2.5.10",
     "mocha": "~1.11.0",
@@ -39,5 +42,11 @@
     "completion",
     "autocomplete",
     "typeahead"
-  ]
+  ],
+  "foundry": {
+    "releaseCommands": [
+      "foundry-release-git",
+      "foundry-release-npm"
+    ]
+  }
 }


### PR DESCRIPTION
Over the past 2 weeks, my tool I have been using for releases went to its v4 iteration. This means it's no longer a global CLI tool but now local/per-repo. This PR adds the necessary integration for `foundry`. In this PR:
- Added dev dependencies for `foundry`
- Added `foundry` configuration to `package.json`

**Notes:**

Details in blog post: http://twolfson.com/2015-10-17-release-foundry-v4

/cc @brettlangdon 
